### PR TITLE
fix(Programming Basics - if Expressions - Exercise 4): The descriptio…

### DIFF
--- a/Programming Basics/if Expressions/Exercise 4/task.md
+++ b/Programming Basics/if Expressions/Exercise 4/task.md
@@ -2,7 +2,7 @@
 
 To navigate to a function definition, put the caret on the usage and press
 <span class="shortcut">&shortcut:GotoDeclaration;</span>. Alternatively, you
-can click on the symbol while holding the Ctrl (or ⌘) key.
+can click on the symbol while holding the Ctrl key (or the Command key on Mac).
 
 Put the caret on the `oneOrTheOther()` function call in `main()` and navigate
 to the function definition.


### PR DESCRIPTION
…n of the loop square altered to avoid it not rendering on windows/linux

The ⌘ is not renderred correctly in the task description, so it was
switched to the key name

Closes https://youtrack.jetbrains.com/issue/EDC-416