### PR TITLE
fix(Programming Basics - Hello, World - Exercise 5): Shortcuts for li…

### DIFF
--- a/Programming Basics/Hello, World/Exercise 5/task.md
+++ b/Programming Basics/Hello, World/Exercise 5/task.md
@@ -18,8 +18,8 @@ the beginning of a line:
 |-----------------------------------|-----------------------------------------------------------------------|----------------------------------------------------------------|
 | Up with selection                 | <span class="shortcut">&shortcut:EditorUpWithSelection;</span>        | Move the caret one line up, selecting the text.                |
 | Right with selection              | <span class="shortcut">&shortcut:EditorRightWithSelection;</span>     | Move the caret one character to the right, selecting the text. |
-| Move to line end with selection   | <span class="shortcut">&shortcut:EditorTextEndWithSelection;</span>   | Move the caret to the end of line, selecting the text.         |
-| Move to line start with selection | <span class="shortcut">&shortcut:EditorTextStartWithSelection;</span> | Move the caret to the beginning of line, selecting the text.   |
+| Move to line end with selection   | <span class="shortcut">&shortcut:EditorLineEndWithSelection;</span>   | Move the caret to the end of line, selecting the text.         |
+| Move to line start with selection | <span class="shortcut">&shortcut:EditorLineStartWithSelection;</span> | Move the caret to the beginning of line, selecting the text.   |
 
 Duplicate the line `println("Hello, Kotlin!")` in the example by selecting it
 and then copy-pasting it.


### PR DESCRIPTION
…ne start/end fixed

The shortcut links in the description were fixed to match their
description:
EditorTextStartWithSelection ->
EditorLineStartWithSelection
EditorTextEndWithSelection ->
EditorLineEndWithSelection
The decision to fix the links not the
descriptions is based on the task itself being to select a line, not the
whole text.

Closes https://youtrack.jetbrains.com/issue/EDC-413