### PR TITLE
fix(Task description Named and Default Arguments (#4)): Corrected des…

### DIFF
--- a/Usability/Named & Default Arguments/Exercise 4/task.md
+++ b/Usability/Named & Default Arguments/Exercise 4/task.md
@@ -11,7 +11,7 @@ be updated correspondingly.
 Put the caret on `foo()` and select the <span class="control">`Change
 Signature`</span> refactoring. Press the icon with the plus symbol (`+`) to add
 one more parameter. Specify its name as `d` and its type as `Double` with a
-default value of `1.0`. Press <span class="control">`EditorEnter`</span> or
+default value of `1.0`. Press <span class="control">`Enter`</span> or
 click the <span class="control">`Refactor`</span> button. Note how the callers
 change: the default value is now used for all the callers. Add the same
 parameter to `bar()` without specifying the default value.


### PR DESCRIPTION
…cription

It used to read "Press EditorEnter or click the Refactor button".
Replaced "EditorEnter" with "Enter"

Closes https://youtrack.jetbrains.com/issue/EDC-438