### PR TITLE
fix(Task description Operator Overloading #3): Changed description of r…

### DIFF
--- a/Power Tools/Operator Overloading/Exercise 3/task.md
+++ b/Power Tools/Operator Overloading/Exercise 3/task.md
@@ -9,11 +9,11 @@ operations for a `Repository` named `r`:
   there are no `null` locations remaining, appends `rv` to the end of `list`.
 
 - `r[n] = rv` Places `rv` into location `n` in `list`. Requires that `n` be
-  greater than zero and less than `list.size`. Requires that `list[n]` be
+  equal to or greater than zero and less than `list.size`. Requires that `list[n]` be
   non-`null`.
 
-- `r[n]` Retrieves the value `list[n]`. Requires that `n` be greater than zero
-  and less than `list.size`. Requires that `list[n]` be non-`null`.
+- `r[n]` Retrieves the value `list[n]`. Requires that `n` be equal to or greater 
+  than zero and less than `list.size`. Requires that `list[n]` be non-`null`.
 
 Add a `toString()` that produces `list` separated by commas.
 


### PR DESCRIPTION
…equirements for n

Replaced "greater than zero" with "equal to or greater than zero" for n
requirements

Closes https://youtrack.jetbrains.com/issue/EDC-458