### PR TITLE
fix(Answer placeholders OOP Sealed Classes #1): Added answer placeholders

### DIFF
--- a/Object-Oriented Programming/Sealed Classes/Exercise 1/task-info.yaml
+++ b/Object-Oriented Programming/Sealed Classes/Exercise 1/task-info.yaml
@@ -3,8 +3,23 @@ files:
 - name: src/Task.kt
   visible: true
   placeholders:
-  - offset: 82
-    length: 997
+  - offset: 307
+    length: 82
     placeholder_text: // TODO
+  - offset: 391
+    length: 90
+    placeholder_text: // TODO
+  - offset: 651
+    length: 112
+    placeholder_text: // TODO
+  - offset: 770
+    length: 35
+    placeholder_text: // TODO
+  - offset: 877
+    length: 47
+    placeholder_text: // TODO
+  - offset: 109
+    length: 26
+    placeholder_text: TODO()
 - name: test/Tests.kt
   visible: false


### PR DESCRIPTION
Placeholders corresponding to the things mentioned in the description
were missing, there was a giant one covering the whole task with no
starter code shown to the student.