### PR TITLE
fix(Nested Classes - Exercises 2/3 Task description Answer placeholders): Split answer placeholders

### DIFF
--- a/Object-Oriented Programming/Nested Classes/Exercise 2/task-info.yaml
+++ b/Object-Oriented Programming/Nested Classes/Exercise 2/task-info.yaml
@@ -3,8 +3,17 @@ files:
 - name: src/Task.kt
   visible: true
   placeholders:
-  - offset: 82
-    length: 1317
-    placeholder_text: // TODO
+  - offset: 579
+    length: 20
+    placeholder_text: /*TODO*/
+  - offset: 652
+    length: 33
+    placeholder_text: /*TODO*/
+  - offset: 794
+    length: 11
+    placeholder_text: /*TODO*/
+  - offset: 889
+    length: 35
+    placeholder_text: /*TODO*/
 - name: test/Tests.kt
   visible: false

--- a/Object-Oriented Programming/Nested Classes/Exercise 2/task.md
+++ b/Object-Oriented Programming/Nested Classes/Exercise 2/task.md
@@ -1,6 +1,6 @@
 ## Nested Classes (#2)
 
-In `NestedHouse.kt`, add two `Drawer`s to `Closet` and a `Bathtub` to
+In the modified `NestedHouse.kt` (functions `clean()` and `main()` were changed a bit), add two `Drawer`s to `Closet` and a `Bathtub` to
 `Bathroom`.
 
 <sub> This task doesn't contain automatic tests,

--- a/Object-Oriented Programming/Nested Classes/Exercise 3/task-info.yaml
+++ b/Object-Oriented Programming/Nested Classes/Exercise 3/task-info.yaml
@@ -3,8 +3,11 @@ files:
 - name: src/Task.kt
   visible: true
   placeholders:
-  - offset: 82
-    length: 1027
-    placeholder_text: // TODO
+  - offset: 674
+    length: 92
+    placeholder_text: /*TODO*/
+  - offset: 244
+    length: 391
+    placeholder_text: /*TODO*/
 - name: test/Tests.kt
   visible: false


### PR DESCRIPTION
Due to the things described in the issue I thought it would be better to
make smaller placeholders to keep the changed portions (clean() and main())
in the starter code to avoid confusion. Added a note in the Ex.2 about
the fact that NestedHouse.kt was slightly modified

Closes https://youtrack.jetbrains.com/issue/EDC-471