### PR TITLE
fix(Objects 1 Answer placeholders): Split answer placeholders

### DIFF
--- a/Object-Oriented Programming/Objects/Exercise 1/src/Task.kt
+++ b/Object-Oriented Programming/Objects/Exercise 1/src/Task.kt
@@ -16,12 +16,13 @@ private object Space2 {
 }
 
 fun main() {
-  f()
+/*  f()
   Space.f()
   Space2.f()
   trace eq """
     f() p
     Space.f() Space.p
     Space2.f() Space2.p
-  """
+  """ 
+ */
 }

--- a/Object-Oriented Programming/Objects/Exercise 1/task-info.yaml
+++ b/Object-Oriented Programming/Objects/Exercise 1/task-info.yaml
@@ -3,8 +3,14 @@ files:
 - name: src/Task.kt
   visible: true
   placeholders:
+  - offset: 142
+    length: 59
+    placeholder_text: /*TODO*/
+  - offset: 231
+    length: 61
+    placeholder_text: /*TODO*/
   - offset: 70
-    length: 348
-    placeholder_text: // TODO
+    length: 53
+    placeholder_text: /*TODO*/
 - name: test/Tests.kt
   visible: false

--- a/Object-Oriented Programming/Objects/Exercise 1/task-info.yaml
+++ b/Object-Oriented Programming/Objects/Exercise 1/task-info.yaml
@@ -3,14 +3,14 @@ files:
 - name: src/Task.kt
   visible: true
   placeholders:
+  - offset: 70
+    length: 53
+    placeholder_text: /*TODO*/
   - offset: 142
     length: 59
     placeholder_text: /*TODO*/
   - offset: 231
     length: 61
-    placeholder_text: /*TODO*/
-  - offset: 70
-    length: 53
     placeholder_text: /*TODO*/
 - name: test/Tests.kt
   visible: false


### PR DESCRIPTION
The description mentions: "The starter code in main() will show you how
to write these."
but there was no main() in the starter code, only a
package name, import statement, and a //todo. Changed placeholders to
keep necessary parts in the starter code

Closes https://youtrack.jetbrains.com/issue/EDC-472