### PR TITLE
fix(Summary 2 Quadratic.kt Example): corrected a formula

### DIFF
--- a/Introduction to Objects/Summary 2/Examples/src/Quadratic.kt
+++ b/Introduction to Objects/Summary 2/Examples/src/Quadratic.kt
@@ -21,8 +21,8 @@ fun quadraticZeroes(
     throw IllegalArgumentException(
       "Negative underRadical: $underRadical")
   val squareRoot = sqrt(underRadical)
-  val root1 = (-b - squareRoot) / 2 * a
-  val root2 = (-b + squareRoot) / 2 * a
+  val root1 = (-b - squareRoot) / (2 * a)
+  val root2 = (-b + squareRoot) / (2 * a)
   return Roots(root1, root2)
 }
 


### PR DESCRIPTION
based on the operator precedence rules for / and * the formula should be
(-b + squareRoot) / (2 * a) and not (-b + squareRoot) / 2 * a
(same for
the other one)

Closes https://youtrack.jetbrains.com/issue/EDC-487