### PR TITLE
fix(Operator Overloading - Arithmetic Operators Example): Corrected e…

### DIFF
--- a/Power Tools/Operator Overloading/Examples/src/ArithmeticOperators.kt
+++ b/Power Tools/Operator Overloading/Examples/src/ArithmeticOperators.kt
@@ -25,8 +25,8 @@ fun unary(a: E) {
 operator fun E.plus(e: E) = E(v + e.v)
 operator fun E.minus(e: E) = E(v - e.v)
 operator fun E.times(e: E) = E(v * e.v)
-operator fun E.div(e: E) = E(v % e.v)
-operator fun E.rem(e: E) = E(v / e.v)
+operator fun E.div(e: E) = E(v / e.v)
+operator fun E.rem(e: E) = E(v % e.v)
 
 fun binary(a: E, b: E) {
   a + b            // a.plus(b)


### PR DESCRIPTION
…xt, function operators in E.div() and E.rem()

(the operators used in the extension functions were swapped)

Closes https://youtrack.jetbrains.com/issue/EDC-457