### PR TITLE
refactor(Lambdas - Mapping Example): Replaced a deprecated function, moved lamb…

### DIFF
--- a/Functional Programming/Lambdas/Examples/src/Mapping.kt
+++ b/Functional Programming/Lambdas/Examples/src/Mapping.kt
@@ -4,6 +4,6 @@ import atomictest.eq
 fun main() {
   val list = listOf('a', 'b', 'c', 'd')
   val result =
-    list.map({ "[${it.toUpperCase()}]" })
+    list.map { "[${it.uppercaseChar()}]" }
   result eq listOf("[A]", "[B]", "[C]", "[D]")
 }


### PR DESCRIPTION
…da argument out of parentheses following IDE inspection

Closes https://youtrack.jetbrains.com/issue/EDC-502