### PR TITLE
style(Task Description Sequences 7): Removed a reportedly confusing bit

### DIFF
--- a/Functional Programming/Sequences/Exercise 7/task.md
+++ b/Functional Programming/Sequences/Exercise 7/task.md
@@ -1,7 +1,7 @@
 ## Sequences (#7)
 
-Write a function `oddWithout1()` that creates an infinite sequence of odd
-numbers starting with `3` that do not contain the digit `1` in its decimal
+Write a function `oddWithout1()` that creates an infinite sequence of positive odd
+numbers that do not contain the digit `1` in its decimal
 representation:
 
 ```text


### PR DESCRIPTION
The task stated "...infinite sequence of odd numbers starting with 3",
while the solution uses `return generateSequence(1) { it + 2 }`, which
was reported as confusing by a user. Dropped the phrase "starting with
3"

Closes https://youtrack.jetbrains.com/issue/EDC-506